### PR TITLE
Added checking of chunks to improve DX in error cases.

### DIFF
--- a/src/flushChunks.js
+++ b/src/flushChunks.js
@@ -64,7 +64,7 @@ const flushChunks = (stats: Stats, isWebpack: boolean, opts: Options = {}) => {
   const jsBefore = filesFromChunks(beforeEntries, stats.assetsByChunkName)
 
   const files = opts.chunkNames
-    ? filesFromChunks(opts.chunkNames, stats.assetsByChunkName)
+    ? filesFromChunks(opts.chunkNames, stats.assetsByChunkName, true)
     : flush(opts.moduleIds || [], stats, opts.rootDir, isWebpack)
 
   const afterEntries = opts.after || defaults.after
@@ -191,9 +191,18 @@ const concatFilesAtKeys = (
 
 const filesFromChunks = (
   chunkNames: Files,
-  assetsByChunkName: FilesMap
+  assetsByChunkName: FilesMap,
+  check: boolean
 ): Files => {
-  const hasChunk = entry => !!assetsByChunkName[entry]
+  const hasChunk = entry => { 
+    const result = !!assetsByChunkName[entry]
+    if (!result && checkChunkName) {
+      console.warn(`[FLUSH CHUNKS]: Unable to find ${entry} in Webpack chunks. Please check usage of Babel plugin.`)     
+    }
+    
+    return result
+  }
+    
   const entryToFiles = entry => assetsByChunkName[entry]
 
   return [].concat(...chunkNames.filter(hasChunk).map(entryToFiles))

--- a/src/flushChunks.js
+++ b/src/flushChunks.js
@@ -192,17 +192,17 @@ const concatFilesAtKeys = (
 const filesFromChunks = (
   chunkNames: Files,
   assetsByChunkName: FilesMap,
-  check: boolean
+  checkChunkNames: boolean
 ): Files => {
-  const hasChunk = entry => { 
+  const hasChunk = entry => {
     const result = !!assetsByChunkName[entry]
-    if (!result && checkChunkName) {
-      console.warn(`[FLUSH CHUNKS]: Unable to find ${entry} in Webpack chunks. Please check usage of Babel plugin.`)     
+    if (!result && checkChunkNames) {
+      console.warn(`[FLUSH CHUNKS]: Unable to find ${entry} in Webpack chunks. Please check usage of Babel plugin.`)
     }
-    
+
     return result
   }
-    
+
   const entryToFiles = entry => assetsByChunkName[entry]
 
   return [].concat(...chunkNames.filter(hasChunk).map(entryToFiles))


### PR DESCRIPTION
When there is some issue in the Babel configuration e.g. missing comments in source files after transpile, the current behavior fails without reporting any error. In my opinion it seems safe to add a test for all passed over `chunkNames` and validate whether they exist in the assets as well. If not, report an error.