### PR TITLE
Add defer to script tags for loading purposes

### DIFF
--- a/__tests__/__snapshots__/createApiWithCss.test.js.snap
+++ b/__tests__/__snapshots__/createApiWithCss.test.js.snap
@@ -3,10 +3,12 @@
 exports[`createApiWithCss() generates js + style components, strings and arrays 1`] = `
 <span>
   <script
+    defer={true}
     src="/static/0.js"
     type="text/javascript"
   />
   <script
+    defer={true}
     src="/static/main.js"
     type="text/javascript"
   />
@@ -38,8 +40,8 @@ exports[`createApiWithCss() generates js + style components, strings and arrays 
 `;
 
 exports[`createApiWithCss() generates js + style components, strings and arrays 4`] = `
-"<script type='text/javascript' src='/static/0.js'></script>
-<script type='text/javascript' src='/static/main.js'></script>"
+"<script type='text/javascript' src='/static/0.js' defer></script>
+<script type='text/javascript' src='/static/main.js' defer></script>"
 `;
 
 exports[`createApiWithCss() generates js + style components, strings and arrays 5`] = `
@@ -71,6 +73,7 @@ Array [
 exports[`createApiWithCss() uses files with extension "no_css.js" if available 1`] = `
 <span>
   <script
+    defer={true}
     src="/static/main.no_css.js"
     type="text/javascript"
   />
@@ -95,7 +98,7 @@ exports[`createApiWithCss() uses files with extension "no_css.js" if available 3
 </span>
 `;
 
-exports[`createApiWithCss() uses files with extension "no_css.js" if available 4`] = `"<script type='text/javascript' src='/static/main.no_css.js'></script>"`;
+exports[`createApiWithCss() uses files with extension "no_css.js" if available 4`] = `"<script type='text/javascript' src='/static/main.no_css.js' defer></script>"`;
 
 exports[`createApiWithCss() uses files with extension "no_css.js" if available 5`] = `"<link rel='stylesheet' href='/static/main.css' />"`;
 

--- a/src/createApiWithCss.js
+++ b/src/createApiWithCss.js
@@ -55,6 +55,7 @@ export default (
             type='text/javascript'
             src={`${publicPath}/${file}`}
             key={key}
+            defer
           />
         ))}
       </span>
@@ -74,7 +75,7 @@ export default (
         scripts
           .map(
             file =>
-              `<script type='text/javascript' src='${publicPath}/${file}'></script>`
+              `<script type='text/javascript' src='${publicPath}/${file}' defer></script>`
           )
           .join('\n')
     },


### PR DESCRIPTION
## Motivation

Tools like Google's PageSpeed will complain if a `script` tag blocks DOM parsing/execution, even if the `script` tags are the last elements of the body. You can resolve this either by adding an `async` flag or a `defer` flag. The `async` flag is the preferred option in general, but can result in out-of-order loading and execution, which isn't good when combined with `webpack` modules. `defer` is the next best thing.

There aren't, as I understand it, any potential issues with adding a `defer` flag.

## Changes
* Add `defer` flag to Js component output
* Add `defer` flag to `js` string output
* Update test snapshots

## Other potential approaches
This could also be done by adding prop pass through or a `defer` prop to the `Js` component that is returned. Would this be preferable?