### PR TITLE
Change React.Element to React$Element as Element is not a named export of the React flow module

### DIFF
--- a/src/createApiWithCss.js
+++ b/src/createApiWithCss.js
@@ -8,7 +8,7 @@ export type CssChunksHash = {
   [key: string]: string
 }
 
-type StatelessComponent = () => React.Element<*>
+type StatelessComponent = () => React$Element<*>
 type ObjectString = {
   toString: () => string
 }


### PR DESCRIPTION
Flow ("flow-bin": "^0.57.3") via Yarn ("v1.2.1") was giving me an error for webpack flush chunks ("webpack-flush-chunks": "^1.1.23"):

```
yarn run v1.2.1
$ flow check
Error: node_modules/webpack-flush-chunks/dist/createApiWithCss.js.flow:11
 11: type StatelessComponent = () => React.Element<*>
                                     ^^^^^^^^^^^^^^^^ Element. Property not found in
                              v-
239:   declare export default {|
240:     +DOM: typeof DOM,
241:     +PropTypes: typeof PropTypes,
...:
253:   |};
       -^ object type. See lib: /tmp/flow/flowlib_394f9382/react.js:239
```

Here is the reference typing for react (via flow): https://github.com/facebook/flow/blob/master/lib/react.js#L240

Manually changing `React.Element<*>` to `React$Element<*>` on line 11 of `node_modules/webpack-flush-chunks/dist/createApiWithCss.js.flow` fixes the issue for me.

Opening in case this proves to be the way to solve this issue.