### PR TITLE
fix($typescript): Fix typo in TypeScript definition file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare module 'webpack-flush-chunks' {
     stylesheets: string[];
 
     /** Hash object of chunk names to CSS file paths */
-    cssHashRaw: Recrod<string, string>;
+    cssHashRaw: Record<string, string>;
 
     /** `<script>window.__CSS_CHUNKS__ = ${JSON.stringify(cssHashRaw)}</script>` */
     cssHash: string[];


### PR DESCRIPTION
Noticed a small typo in index.d.ts - Recrod -> Record. 

For now I'm using this as a workaround:

```
type Recrod<K extends string, T> = Record<K, T>;
```

but it would be nice to get this fixed :)