### PR TITLE
fix(xhtml): Fixed XHTML output compatiblity with "defer" attribute.

### DIFF
--- a/__tests__/__snapshots__/createApiWithCss.test.js.snap
+++ b/__tests__/__snapshots__/createApiWithCss.test.js.snap
@@ -40,8 +40,8 @@ exports[`createApiWithCss() generates js + style components, strings and arrays 
 `;
 
 exports[`createApiWithCss() generates js + style components, strings and arrays 4`] = `
-"<script type='text/javascript' src='/static/0.js' defer></script>
-<script type='text/javascript' src='/static/main.js' defer></script>"
+"<script type='text/javascript' src='/static/0.js' defer='defer'></script>
+<script type='text/javascript' src='/static/main.js' defer='defer'></script>"
 `;
 
 exports[`createApiWithCss() generates js + style components, strings and arrays 5`] = `
@@ -98,7 +98,7 @@ exports[`createApiWithCss() uses files with extension "no_css.js" if available 3
 </span>
 `;
 
-exports[`createApiWithCss() uses files with extension "no_css.js" if available 4`] = `"<script type='text/javascript' src='/static/main.no_css.js' defer></script>"`;
+exports[`createApiWithCss() uses files with extension "no_css.js" if available 4`] = `"<script type='text/javascript' src='/static/main.no_css.js' defer='defer'></script>"`;
 
 exports[`createApiWithCss() uses files with extension "no_css.js" if available 5`] = `"<link rel='stylesheet' href='/static/main.css' />"`;
 

--- a/src/createApiWithCss.js
+++ b/src/createApiWithCss.js
@@ -75,7 +75,7 @@ export default (
         scripts
           .map(
             file =>
-              `<script type='text/javascript' src='${publicPath}/${file}' defer></script>`
+              `<script type='text/javascript' src='${publicPath}/${file}' defer='defer'></script>`
           )
           .join('\n')
     },
@@ -91,17 +91,19 @@ export default (
     // Use as a React component (<Css />) or a string (`${css}`):
     // NOTE: during development, HMR requires stylesheets.
     Css: () =>
-      (DEV
-        ? api.Styles()
-        : <span>
+      DEV ? (
+        api.Styles()
+      ) : (
+        <span>
           <style>{stylesAsString(stylesheets, outputPath)}</style>
-        </span>),
+        </span>
+      ),
     css: {
       toString: () =>
         // lazy-loaded in case not used
-        (DEV
+        DEV
           ? api.styles.toString()
-          : `<style>${stylesAsString(stylesheets, outputPath)}</style>`)
+          : `<style>${stylesAsString(stylesheets, outputPath)}</style>`
     },
 
     // 4) names of files without publicPath or outputPath prefixed:
@@ -124,7 +126,9 @@ export default (
     ),
     cssHash: {
       toString: () =>
-        `<script type='text/javascript'>window.__CSS_CHUNKS__= ${JSON.stringify(cssHashRaw)}</script>`
+        `<script type='text/javascript'>window.__CSS_CHUNKS__= ${JSON.stringify(
+          cssHashRaw
+        )}</script>`
     }
   }
 
@@ -149,7 +153,7 @@ export const stylesAsString = (
 ): string => {
   if (!outputPath) {
     throw new Error(
-      `No \`outputPath\` was provided as an option to \`flushChunks\`. 
+      `No \`outputPath\` was provided as an option to \`flushChunks\`.
       Please provide one so stylesheets can be read from the
       file system since you're embedding the css as a string.`
     )


### PR DESCRIPTION
When using this for XHTML documents the currently generated output is invalid XHTML which breaks our TV output right now. I changed the syntax by some detail to assign a value to it. Hopefully this finds its place into some release ASAP. Thanks :)