### PR TITLE
fix: account for there being no chunk with the same name as the chunk group

### DIFF
--- a/__fixtures__/stats.js
+++ b/__fixtures__/stats.js
@@ -22,14 +22,43 @@ const chunk3Files = [
   '2.no_css.js.map',
   '2.css.map'
 ]
+const chunk4Files = [
+  '3.js',
+  '3.no_css.js',
+  '3.css',
+  '3.js.map',
+  '3.no_css.js.map',
+  '3.css.map'
+]
 
 export const stats = {
   assetsByChunkName: {
-    bootstrap: ['bootstrap.js', 'bootstrap.no_css.js'],
+    'bootstrap~..arbitrary': [
+      'bootstrap~..arbitrary.js',
+      'bootstrap~..arbitrary.no_css.js'
+    ],
     vendor: ['vendor.js', 'vendor.no_css.js'],
     main: ['main.js', 'main.no_css.js', 'main.css'],
-    chunk1: chunk1Files,
+    'chunk1~common1': chunk1Files,
+    'chunk1~common2': chunk4Files,
     chunk2: chunk2Files
+  },
+  namedChunkGroups: {
+    bootstrap: {
+      chunks: ['bootstrap~..arbitrary']
+    },
+    vendor: {
+      chunks: ['vendor']
+    },
+    main: {
+      chunks: ['main']
+    },
+    chunk1: {
+      chunks: ['chunk1~common1', 'chunk1~common2']
+    },
+    chunk2: {
+      chunks: ['chunk2']
+    }
   },
   chunks: [
     {

--- a/__tests__/__snapshots__/createApiWithCss.test.js.snap
+++ b/__tests__/__snapshots__/createApiWithCss.test.js.snap
@@ -121,7 +121,8 @@ Array [
 
 exports[`unit tests createCssHash() 1`] = `
 Object {
-  "chunk1": "/static/0.css",
+  "chunk1~common1": "/static/0.css",
+  "chunk1~common2": "/static/3.css",
   "chunk2": "/static/1.css",
   "main": "/static/main.css",
 }

--- a/__tests__/__snapshots__/flushChunks.test.js.snap
+++ b/__tests__/__snapshots__/flushChunks.test.js.snap
@@ -13,7 +13,8 @@ Object {
     "toString": [Function],
   },
   "cssHashRaw": Object {
-    "chunk1": "/static/0.css",
+    "chunk1~common1": "/static/0.css",
+    "chunk1~common2": "/static/3.css",
     "chunk2": "/static/1.css",
     "main": "/static/main.css",
   },
@@ -23,9 +24,10 @@ Object {
   "outputPath": undefined,
   "publicPath": "/static",
   "scripts": Array [
-    "bootstrap.no_css.js",
+    "bootstrap~..arbitrary.no_css.js",
     "vendor.no_css.js",
     "0.no_css.js",
+    "3.no_css.js",
     "1.no_css.js",
     "main.no_css.js",
   ],
@@ -35,6 +37,7 @@ Object {
   "stylesheets": Array [
     "main.css",
     "0.css",
+    "3.css",
     "1.css",
   ],
 }
@@ -53,7 +56,8 @@ Object {
     "toString": [Function],
   },
   "cssHashRaw": Object {
-    "chunk1": "/static/0.css",
+    "chunk1~common1": "/static/0.css",
+    "chunk1~common2": "/static/3.css",
     "chunk2": "/static/1.css",
     "main": "/static/main.css",
   },
@@ -63,7 +67,7 @@ Object {
   "outputPath": undefined,
   "publicPath": "/static",
   "scripts": Array [
-    "bootstrap.no_css.js",
+    "bootstrap~..arbitrary.no_css.js",
     "vendor.no_css.js",
     "0.no_css.js",
     "1.no_css.js",
@@ -95,7 +99,8 @@ Object {
     "toString": [Function],
   },
   "cssHashRaw": Object {
-    "chunk1": "/static/0.css",
+    "chunk1~common1": "/static/0.css",
+    "chunk1~common2": "/static/3.css",
     "chunk2": "/static/1.css",
     "main": "/static/main.css",
   },
@@ -136,7 +141,8 @@ Object {
     "toString": [Function],
   },
   "cssHashRaw": Object {
-    "chunk1": "/static/0.css",
+    "chunk1~common1": "/static/0.css",
+    "chunk1~common2": "/static/3.css",
     "chunk2": "/static/1.css",
     "main": "/static/main.css",
   },
@@ -146,9 +152,10 @@ Object {
   "outputPath": undefined,
   "publicPath": "/static",
   "scripts": Array [
-    "bootstrap.no_css.js",
+    "bootstrap~..arbitrary.no_css.js",
     "vendor.no_css.js",
     "0.no_css.js",
+    "3.no_css.js",
     "1.no_css.js",
     "main.no_css.js",
   ],
@@ -158,6 +165,7 @@ Object {
   "stylesheets": Array [
     "main.css",
     "0.css",
+    "3.css",
     "1.css",
   ],
 }
@@ -176,7 +184,8 @@ Object {
     "toString": [Function],
   },
   "cssHashRaw": Object {
-    "chunk1": "/static/0.css",
+    "chunk1~common1": "/static/0.css",
+    "chunk1~common2": "/static/3.css",
     "chunk2": "/static/1.css",
     "main": "/static/main.css",
   },
@@ -186,7 +195,7 @@ Object {
   "outputPath": undefined,
   "publicPath": "/static",
   "scripts": Array [
-    "bootstrap.no_css.js",
+    "bootstrap~..arbitrary.no_css.js",
     "vendor.no_css.js",
     "0.no_css.js",
     "1.no_css.js",
@@ -218,7 +227,8 @@ Object {
     "toString": [Function],
   },
   "cssHashRaw": Object {
-    "chunk1": "/static/0.css",
+    "chunk1~common1": "/static/0.css",
+    "chunk1~common2": "/static/3.css",
     "chunk2": "/static/1.css",
     "main": "/static/main.css",
   },
@@ -254,6 +264,12 @@ Array [
   "0.js.map",
   "0.no_css.js.map",
   "0.css.map",
+  "3.js",
+  "3.no_css.js",
+  "3.css",
+  "3.js.map",
+  "3.no_css.js.map",
+  "3.css.map",
   "1.js",
   "1.no_css.js",
   "1.css",
@@ -289,6 +305,7 @@ Array [
 exports[`flushFiles() called as a pure function filter: by function 1`] = `
 Array [
   "0.css",
+  "3.css",
   "1.css",
 ]
 `;
@@ -296,6 +313,7 @@ Array [
 exports[`flushFiles() called as a pure function filter: by regex 1`] = `
 Array [
   "0.css",
+  "3.css",
   "1.css",
 ]
 `;
@@ -303,6 +321,7 @@ Array [
 exports[`flushFiles() called as a pure function filter: by string (file extension) 1`] = `
 Array [
   "0.css",
+  "3.css",
   "1.css",
 ]
 `;
@@ -315,6 +334,12 @@ Array [
   "0.js.map",
   "0.no_css.js.map",
   "0.css.map",
+  "3.js",
+  "3.no_css.js",
+  "3.css",
+  "3.js.map",
+  "3.no_css.js.map",
+  "3.css.map",
   "1.js",
   "1.no_css.js",
   "1.css",

--- a/__tests__/flushChunks.test.js
+++ b/__tests__/flushChunks.test.js
@@ -9,7 +9,7 @@ import {
   isUnique,
   normalizePath,
   concatFilesAtKeys,
-  filesFromChunks
+  assetsFromChunkGroups
 } from '../src/flushChunks'
 
 import {
@@ -223,13 +223,21 @@ describe('unit tests', () => {
     expect(files).toEqual(['0.js', '0.css', '2.js', '2.css'])
   })
 
-  test('filesFromChunks()', () => {
+  test('assetsFromChunkGroups()', () => {
     const entryNames = ['bootstrap', 'vendor', 'main']
     const assetsByChunkName = {
       bootstrap: ['bootstrap.js'],
       main: ['main.js', 'main.css']
     }
-    const outputFiles = filesFromChunks(entryNames, { assetsByChunkName })
+    const namedChunkGroups = {
+      bootstrap: { chunks: ['bootstrap'] },
+      main: { chunks: ['main'] },
+      vendor: { chunks: ['vendor'] }
+    }
+    const outputFiles = assetsFromChunkGroups(entryNames, {
+      assetsByChunkName,
+      namedChunkGroups
+    })
 
     expect(outputFiles).toEqual(['bootstrap.js', 'main.js', 'main.css'])
   })


### PR DESCRIPTION
Webpack 4 introduced the concept of [chunk groups](https://medium.com/webpack/webpack-4-code-splitting-chunk-graph-and-the-splitchunks-optimization-be739a861366).

I think there has been a false assumption in `webpack-flush-chunks` - that there is at least one chunk with the same name as the chunk group corresponding to the entry point or async chunk (provided via the `before` and `after` parameters and the `chunkNames` parameter respectively.

In an app I was working with this was not the case. The flushing of chunks was failing with the error "... check usage of babel plugin" because `hasChunk` was checking for a chunk with the required name, when it should instead be checking for a chunk group with the required name.

So the changes:
* Rename functions to more accurately refer to the webpack concepts of chunks, chunk groups, entry points, and assets/files
* Update `hasChunk` (now `hasChunkGroup`) to check the `namedChunkGroups` key in the stats object instead of the `assetsByChunkName` key, fixing the bug I experienced.
* Remove the adding of a hyphen to the chunk name, which I assume is a workaround for the same issue
* Update unit tests to add examples where:
   * The chunk name is different from the chunk group/entry point/split point name
   * A chunk group has multiple chunks, none of which have the same name as the chunk group