### PR TITLE
Pass through props in Js and Styles

### DIFF
--- a/__tests__/__snapshots__/createApiWithCss.test.js.snap
+++ b/__tests__/__snapshots__/createApiWithCss.test.js.snap
@@ -127,6 +127,38 @@ Object {
 }
 `;
 
+exports[`unit tests passes additional props through the created component APIs 1`] = `
+<span>
+  <script
+    defer={true}
+    foo="bar"
+    src="/static/0.js"
+    type="text/javascript"
+  />
+  <script
+    defer={true}
+    foo="bar"
+    src="/static/main.js"
+    type="text/javascript"
+  />
+</span>
+`;
+
+exports[`unit tests passes additional props through the created component APIs 2`] = `
+<span>
+  <link
+    foo="bar"
+    href="/static/main.css"
+    rel="stylesheet"
+  />
+  <link
+    foo="bar"
+    href="/static/0.css"
+    rel="stylesheet"
+  />
+</span>
+`;
+
 exports[`unit tests stylesAsString() 1`] = `
 "/Users/jamesgillmore/App/build/main.css- the css! 
 

--- a/__tests__/createApiWithCss.test.js
+++ b/__tests__/createApiWithCss.test.js
@@ -126,4 +126,13 @@ describe('unit tests', () => {
     const hash = createCssHash(stats) /*? $ */
     expect(hash).toMatchSnapshot()
   })
+
+  it('passes additional props through the created component APIs', () => {
+    const files = ['0.js', '0.css', 'main.js', 'main.css']
+    const filesForCss = ['main.js', 'main.css', '0.js', '0.css']
+    const api = createApiWithCss(files, filesForCss, stats, outputPath) /*? $ */
+
+    expect(api.Js({ foo: 'bar' }) /*? $.props.children */).toMatchSnapshot()
+    expect(api.Styles({ foo: 'bar' }) /*? $.props.children */).toMatchSnapshot()
+  })
 })

--- a/src/createApiWithCss.js
+++ b/src/createApiWithCss.js
@@ -48,22 +48,28 @@ export default (
   const api = {
     // 1) Use as React components using ReactDOM.renderToStaticMarkup, eg:
     // <html><Styles /><Js /><html>
-    Js: () => (
+    Js: props => (
       <span>
-        {scripts.map((file, key) => (
+        {scripts.map(file => (
           <script
             type='text/javascript'
             src={`${publicPath}/${file}`}
-            key={key}
+            key={file}
             defer
+            {...props}
           />
         ))}
       </span>
     ),
-    Styles: () => (
+    Styles: props => (
       <span>
-        {stylesheets.map((file, key) => (
-          <link rel='stylesheet' href={`${publicPath}/${file}`} key={key} />
+        {stylesheets.map(file => (
+          <link
+            rel='stylesheet'
+            href={`${publicPath}/${file}`}
+            key={file}
+            {...props}
+          />
         ))}
       </span>
     ),
@@ -91,19 +97,17 @@ export default (
     // Use as a React component (<Css />) or a string (`${css}`):
     // NOTE: during development, HMR requires stylesheets.
     Css: () =>
-      DEV ? (
-        api.Styles()
-      ) : (
-        <span>
+      (DEV
+        ? api.Styles()
+        : <span>
           <style>{stylesAsString(stylesheets, outputPath)}</style>
-        </span>
-      ),
+        </span>),
     css: {
       toString: () =>
         // lazy-loaded in case not used
-        DEV
+        (DEV
           ? api.styles.toString()
-          : `<style>${stylesAsString(stylesheets, outputPath)}</style>`
+          : `<style>${stylesAsString(stylesheets, outputPath)}</style>`)
     },
 
     // 4) names of files without publicPath or outputPath prefixed:
@@ -126,9 +130,7 @@ export default (
     ),
     cssHash: {
       toString: () =>
-        `<script type='text/javascript'>window.__CSS_CHUNKS__= ${JSON.stringify(
-          cssHashRaw
-        )}</script>`
+        `<script type='text/javascript'>window.__CSS_CHUNKS__= ${JSON.stringify(cssHashRaw)}</script>`
     }
   }
 


### PR DESCRIPTION
Fixes #83 

## Motivation
See #83. It'd be nice to be able to pass through additional props, such as a `nonce`, without having to maintain those individual props in the context of this library.

## Changes
* Write tests to the effect of the above
* Add passthrough behavior
* Refactor Js and Styles to use `file` as the key instead of the index